### PR TITLE
Explicitly set language version to C# 6.0 for now.

### DIFF
--- a/osu.Game.Resources/osu.Game.Resources.csproj
+++ b/osu.Game.Resources/osu.Game.Resources.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Fixes ppy/osu#636 until Mono 5.0 is out, where we may or may not want to switch to C#7.