### PR TITLE
Fix loss of precision for flashlight smoothing distance calculations

### DIFF
--- a/osu.Game.Resources/Shaders/sh_CircularFlashlight.fs
+++ b/osu.Game.Resources/Shaders/sh_CircularFlashlight.fs
@@ -1,10 +1,10 @@
 ﻿#include "sh_Flashlight.h"
 
 // highp precision is necessary for vertex positions to prevent catastrophic failure on GL_ES platforms
-vec4 getColourAt(highp vec2 diff, highp vec2 size, lowp vec4 originalColour)
+lowp vec4 getColourAt(highp vec2 diff, highp vec2 size, lowp vec4 originalColour)
 {
-    float dist = length(diff);
-    float flashlightRadius = length(size);
+    highp float dist = length(diff);
+    highp float flashlightRadius = length(size);
 
     return originalColour * vec4(1.0, 1.0, 1.0, smoothstep(flashlightRadius, flashlightRadius * smoothness, dist));
 }

--- a/osu.Game.Resources/Shaders/sh_CircularFlashlight.fs
+++ b/osu.Game.Resources/Shaders/sh_CircularFlashlight.fs
@@ -1,6 +1,7 @@
 ﻿#include "sh_Flashlight.h"
 
-vec4 getColourAt(vec2 diff, vec2 size, vec4 originalColour)
+// highp diff prevents loss in precision when calculating smoothing distance on GL_ES platforms
+vec4 getColourAt(highp vec2 diff, vec2 size, vec4 originalColour)
 {
     float dist = length(diff);
     float flashlightRadius = length(size);

--- a/osu.Game.Resources/Shaders/sh_CircularFlashlight.fs
+++ b/osu.Game.Resources/Shaders/sh_CircularFlashlight.fs
@@ -1,7 +1,7 @@
 ﻿#include "sh_Flashlight.h"
 
-// highp diff prevents loss in precision when calculating smoothing distance on GL_ES platforms
-vec4 getColourAt(highp vec2 diff, vec2 size, vec4 originalColour)
+// highp precision is necessary for vertex positions to prevent catastrophic failure on GL_ES platforms
+vec4 getColourAt(highp vec2 diff, highp vec2 size, lowp vec4 originalColour)
 {
     float dist = length(diff);
     float flashlightRadius = length(size);

--- a/osu.Game.Resources/Shaders/sh_Flashlight.h
+++ b/osu.Game.Resources/Shaders/sh_Flashlight.h
@@ -1,9 +1,3 @@
-﻿#ifndef GL_ES
-    #define lowp
-    #define mediump
-    #define highp
-#endif
-
 varying highp vec2 v_Position;
 varying lowp vec4 v_Colour;
 

--- a/osu.Game.Resources/Shaders/sh_Flashlight.h
+++ b/osu.Game.Resources/Shaders/sh_Flashlight.h
@@ -1,5 +1,5 @@
 ﻿#ifdef GL_ES
-    precision highp float;
+    precision mediump float;
 #endif
 
 varying vec2 v_Position;

--- a/osu.Game.Resources/Shaders/sh_Flashlight.h
+++ b/osu.Game.Resources/Shaders/sh_Flashlight.h
@@ -1,5 +1,9 @@
 ﻿#ifdef GL_ES
     precision mediump float;
+    // Not all GPUs support high precision, so we should fall back to medium precision.
+    #ifndef GL_FRAGMENT_PRECISION_HIGH
+        #define highp
+    #endif
 #else
     // Since glsl 1.1 doesn't define precision qualifiers but GL_ES does, 
     // Define them as nothing to avoid compilation issues.
@@ -7,17 +11,20 @@
     #define highp
 #endif
 
-varying vec2 v_Position;
-varying vec4 v_Colour;
 
-uniform vec2 flashlightPos;
-uniform vec2 flashlightSize;
 
-uniform float flashlightDim;
+
+varying highp vec2 v_Position;
+varying lowp vec4 v_Colour;
+
+uniform highp vec2 flashlightPos;
+uniform highp vec2 flashlightSize;
+
+uniform lowp float flashlightDim;
 
 const float smoothness = 1.1;
 
-vec4 getColourAt(vec2, vec2, vec4);
+lowp vec4 getColourAt(vec2, vec2, vec4);
 
 void main(void)
 {

--- a/osu.Game.Resources/Shaders/sh_Flashlight.h
+++ b/osu.Game.Resources/Shaders/sh_Flashlight.h
@@ -1,18 +1,8 @@
-﻿#ifdef GL_ES
-    precision mediump float;
-    // Not all GPUs support high precision, so we should fall back to medium precision.
-    #ifndef GL_FRAGMENT_PRECISION_HIGH
-        #define highp
-    #endif
-#else
-    // Since glsl 1.1 doesn't define precision qualifiers but GL_ES does, 
-    // Define them as nothing to avoid compilation issues.
+﻿#ifndef GL_ES
     #define lowp
+    #define mediump
     #define highp
 #endif
-
-
-
 
 varying highp vec2 v_Position;
 varying lowp vec4 v_Colour;

--- a/osu.Game.Resources/Shaders/sh_Flashlight.h
+++ b/osu.Game.Resources/Shaders/sh_Flashlight.h
@@ -1,6 +1,8 @@
 ﻿#ifdef GL_ES
     precision mediump float;
 #else
+    // Since glsl 1.1 doesn't define precision qualifiers but GL_ES does, 
+    // Define them as nothing to avoid compilation issues.
     #define lowp
     #define highp
 #endif

--- a/osu.Game.Resources/Shaders/sh_Flashlight.h
+++ b/osu.Game.Resources/Shaders/sh_Flashlight.h
@@ -1,5 +1,8 @@
 ﻿#ifdef GL_ES
     precision mediump float;
+#else
+    #define lowp
+    #define highp
 #endif
 
 varying vec2 v_Position;

--- a/osu.Game.Resources/Shaders/sh_Flashlight.h
+++ b/osu.Game.Resources/Shaders/sh_Flashlight.h
@@ -1,5 +1,5 @@
 ﻿#ifdef GL_ES
-    precision mediump float;
+    precision highp float;
 #endif
 
 varying vec2 v_Position;

--- a/osu.Game.Resources/Shaders/sh_RectangularFlashlight.fs
+++ b/osu.Game.Resources/Shaders/sh_RectangularFlashlight.fs
@@ -1,6 +1,6 @@
 ﻿#include "sh_Flashlight.h"
 
-vec4 getColourAt(highp vec2 diff, highp vec2 size, lowp vec4 originalColour)
+lowp vec4 getColourAt(highp vec2 diff, highp vec2 size, lowp vec4 originalColour)
 {
     diff = abs(diff);
 

--- a/osu.Game.Resources/Shaders/sh_RectangularFlashlight.fs
+++ b/osu.Game.Resources/Shaders/sh_RectangularFlashlight.fs
@@ -1,10 +1,10 @@
 ﻿#include "sh_Flashlight.h"
 
-vec4 getColourAt(vec2 diff, vec2 size, vec4 originalColour)
+vec4 getColourAt(highp vec2 diff, highp vec2 size, lowp vec4 originalColour)
 {
     diff = abs(diff);
 
-    float alpha = length(smoothstep(size, size * smoothness, diff));
+    lowp float alpha = length(smoothstep(size, size * smoothness, diff));
 
     return originalColour * vec4(1.0, 1.0, 1.0, alpha);
 }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/5282
Possibly fixes https://github.com/ppy/osu/issues/4961

Would need confirmation for whether or not this fixes the issue for iOS as well, but this was tested on both a google pixel as well as an emulator.

This was tested using [GAPID](https://github.com/google/gapid), which allows for frame capture on android devices. 

In my testing, I used the `highp` qualifier on `v_Position`, `flashlightPos`, the calculation `flashlightPos - v_Position`, `dist` in `getColourAt`, as well as the return value. No combinations of precision qualifiers on those variables produced any desirable results. 

For example, the following shader would produce the same results as on current master: 

```glsl
#ifdef GL_ES
    precision mediump float;
#endif

varying highp vec2 v_Position;
varying vec4 v_Colour;
uniform highp vec2 flashlightPos;
uniform vec2 flashlightSize;
uniform float flashlightDim;
const float smoothness = 1.1;
highp vec4 getColourAt(vec2, vec2, vec4);

void main(void)
{
    highp vec2 difference = flashlightPos - v_Position;
    highp vec4 result = mix(getColourAt(difference, flashlightSize, v_Colour), vec4(0.0, 0.0, 0.0, 1.0), flashlightDim);
    gl_FragColor = result;
}

highp vec4 getColourAt(vec2 diff, vec2 size, vec4 originalColour)
{
    highp float dist = length(diff);
    float flashlightRadius = length(size);
    return originalColour * vec4(1.0, 1.0, 1.0, smoothstep(flashlightRadius, flashlightRadius * smoothness, dist));
}
```

However, once `highp` is used on the `diff` parameter in `getColourAt`, the smoothing function will behave as it is on desktop platforms.

I originally believed it to be some very absurd result of [Shader Variance](https://www.khronos.org/opengl/wiki/Invariance#Shader), which has undefined precision should the compiler decide to optimize away the stored value. However, forcing invariance on all values using `#pragma STDGL invariant(all)` has not yielded any results.

This was also tested using the emultaor built into GAPID, and it was found that this fix also works for the emulator.