### PR TITLE
Fix GL_ES errors due to missing precision identifiers

### DIFF
--- a/osu.Game.Resources/Shaders/sh_Flashlight.h
+++ b/osu.Game.Resources/Shaders/sh_Flashlight.h
@@ -6,9 +6,9 @@ uniform highp vec2 flashlightSize;
 
 uniform lowp float flashlightDim;
 
-const float smoothness = 1.1;
+const mediump float smoothness = 1.1;
 
-lowp vec4 getColourAt(vec2, vec2, vec4);
+lowp vec4 getColourAt(highp vec2, highp vec2, lowp vec4);
 
 void main(void)
 {


### PR DESCRIPTION
Worked on android, but it seems like iOS is a little more strict.