### PR TITLE
Add code to get assembly reference to resource project

### DIFF
--- a/osu.Game.Resources/ResourceAssembly.cs
+++ b/osu.Game.Resources/ResourceAssembly.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 
 namespace osu.Game.Resources
 {
-    public static class ResourceAssembly
+    public static class OsuResources
     {
-        public static Assembly Assembly => typeof(ResourceAssembly).Assembly;
+        public static Assembly ResourceAssembly => typeof(OsuResources).Assembly;
     }
 }

--- a/osu.Game.Resources/ResourceAssembly.cs
+++ b/osu.Game.Resources/ResourceAssembly.cs
@@ -1,0 +1,9 @@
+using System.Reflection;
+
+namespace osu.Game.Resources
+{
+    public static class ResourceAssembly
+    {
+        public static Assembly Assembly => typeof(ResourceAssembly).Assembly;
+    }
+}


### PR DESCRIPTION
Purpose:
- Avoid using reflection to get reference of resource assembly. (ppy/osu-framework#3050)
- Avoid any assembly trimming tool to mark the resource assembly as unused.