### PR TITLE
Add isolated vertex shader for logo animation

### DIFF
--- a/osu.Game.Resources/Shaders/sh_LogoAnimation.fs
+++ b/osu.Game.Resources/Shaders/sh_LogoAnimation.fs
@@ -1,7 +1,7 @@
 #include "sh_Utils.h"
 
-layout(location = 1) in lowp vec4 v_Colour;
-layout(location = 2) in mediump vec2 v_TexCoord;
+layout(location = 0) in lowp vec4 v_Colour;
+layout(location = 1) in mediump vec2 v_TexCoord;
 
 layout(set = 0, binding = 0) uniform lowp texture2D m_Texture;
 layout(set = 0, binding = 1) uniform lowp sampler m_Sampler;
@@ -16,6 +16,6 @@ layout(location = 0) out vec4 o_Colour;
 void main(void) 
 {
     vec4 colour = toSRGB(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord, -0.9));
-    
+
     o_Colour = colour.r < progress ? toSRGB(vec4(v_Colour.rgb, v_Colour.a * colour.a)) : vec4(0);
 }

--- a/osu.Game.Resources/Shaders/sh_LogoAnimation.vs
+++ b/osu.Game.Resources/Shaders/sh_LogoAnimation.vs
@@ -1,0 +1,18 @@
+#include "sh_Utils.h"
+
+layout(location = 0) in highp vec2 m_Position;
+layout(location = 1) in lowp vec4 m_Colour;
+layout(location = 2) in highp vec2 m_TexCoord;
+layout(location = 3) in highp vec4 m_TexRect;
+layout(location = 4) in mediump vec2 m_BlendRange;
+
+layout(location = 0) out lowp vec4 v_Colour;
+layout(location = 1) out highp vec2 v_TexCoord;
+
+void main(void)
+{
+	v_Colour = m_Colour;
+	v_TexCoord = m_TexCoord;
+
+	gl_Position = g_ProjMatrix * vec4(m_Position, 1.0, 1.0);
+}


### PR DESCRIPTION
On D3D11, this shader is encountering the same issue as the blur shader was, which looks to be related to data alignment, but I haven't figured it out yet.

The solution is to use a custom vertex shader, which is a trimmed down `sh_Texture2D.vs` from o!f only containing the specific outputs required by the fragment shader.