### PR TITLE
Fix flashlight mod not working on Metal

### DIFF
--- a/osu.Game.Resources/Shaders/sh_Flashlight.h
+++ b/osu.Game.Resources/Shaders/sh_Flashlight.h
@@ -16,7 +16,7 @@ lowp vec4 getColourAt(highp vec2, highp vec2, lowp vec4);
 void main(void)
 {
     // todo: workaround for a SPIR-V bug (https://github.com/ppy/osu-framework/issues/5719)
-    float one = g_BackbufferDraw ? 1 : 0;
+    float one = g_WrapModeS >= 0 ? 1 : 0;
 
     o_Colour = mix(getColourAt(flashlightPos - v_Position, flashlightSize, v_Colour), vec4(0.0, 0.0, 0.0, 1.0), flashlightDim) * one;
 }

--- a/osu.Game.Resources/Shaders/sh_Flashlight.h
+++ b/osu.Game.Resources/Shaders/sh_Flashlight.h
@@ -15,5 +15,8 @@ lowp vec4 getColourAt(highp vec2, highp vec2, lowp vec4);
 
 void main(void)
 {
-    o_Colour = mix(getColourAt(flashlightPos - v_Position, flashlightSize, v_Colour), vec4(0.0, 0.0, 0.0, 1.0), flashlightDim);
+    // todo: workaround for a SPIR-V bug (https://github.com/ppy/osu-framework/issues/5719)
+    float one = g_BackbufferDraw ? 1 : 0;
+
+    o_Colour = mix(getColourAt(flashlightPos - v_Position, flashlightSize, v_Colour), vec4(0.0, 0.0, 0.0, 1.0), flashlightDim) * one;
 }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/23368

Yet another bug caused by SPIR-V. I'm PR'ing a workaround for this since flashlight is unplayable on Metal, but I'll spend just a bit of time into the [underlying issue](https://github.com/ppy/osu-framework/issues/5719) while at it.