### PR TITLE
Improve `TriangleBorder` shader

### DIFF
--- a/osu.Game.Resources/Shaders/sh_TriangleBorder.fs
+++ b/osu.Game.Resources/Shaders/sh_TriangleBorder.fs
@@ -13,10 +13,10 @@ layout(std140, set = 0, binding = 0) uniform m_BorderData
 
 layout(location = 0) out vec4 o_Colour;
 
-// Distance to the line with the points (0.0, 1.0) and (0.5, 0.0)
+// Distance to the line which starts at (0.0, 1.0) and ends at (0.5, 0.0)
 highp float dstToSideLine(highp vec2 pixelPos)
 {
-    highp vec2 a = vec2(0.4472, -0.8944);
+    highp vec2 a = vec2(0.4472, -0.8944); // (end - start) / distance(end, start)
     highp vec2 closest = dot(a, pixelPos - vec2(0.0, 1.0)) * a + vec2(0.0, 1.0); // closest point on a line from given position
     return distance(closest, pixelPos);
 }

--- a/osu.Game.Resources/Shaders/sh_TriangleBorder.fs
+++ b/osu.Game.Resources/Shaders/sh_TriangleBorder.fs
@@ -16,11 +16,7 @@ layout(location = 0) out vec4 o_Colour;
 highp float dstToLine(highp vec2 start, highp vec2 end, highp vec2 pixelPos)
 {
     highp float lineLength = distance(end, start);
-
-    if (lineLength < 0.001)
-        return distance(pixelPos, start);
-
-    highp vec2 a = (end - start) / lineLength;
+    highp vec2 a = (end - start) / lineLength; // Within the scope of this shader line length won't be 0
     highp vec2 closest = clamp(dot(a, pixelPos - start), 0.0, lineLength) * a + start; // closest point on a line from given position
     return distance(closest, pixelPos);
 }
@@ -28,18 +24,18 @@ highp float dstToLine(highp vec2 start, highp vec2 end, highp vec2 pixelPos)
 void main(void)
 {
     highp vec2 pixelPos = v_TexCoord / (v_TexRect.zw - v_TexRect.xy);
+    pixelPos.x = 0.5 - abs(pixelPos.x - 0.5); // Mirror coordinate space horizontally (0 -> 1 to 0 -> 0.5 -> 0)
 
     // return if outside the triangle
-    if (abs(pixelPos.x - 0.5) > 0.5 * pixelPos.y)
+    if (pixelPos.y < 1.0 - 2.0 * pixelPos.x)
     {
         o_Colour = vec4(0.0);
         return;
     }
 
-    highp float dst1 = 1.0 - pixelPos.y;
-    highp float dst2 = dstToLine(vec2(1.0), vec2(0.5, 0.0), pixelPos);
-    highp float dst3 = dstToLine(vec2(0.0, 1.0), vec2(0.5, 0.0), pixelPos);
-    highp float dst = min(min(dst1, dst2), dst3);
+    highp float dstToBottom = 1.0 - pixelPos.y;
+    highp float dstToSide = dstToLine(vec2(0.0, 1.0), vec2(0.5, 0.0), pixelPos);
+    highp float dst = min(dstToBottom, dstToSide);
 
     lowp float alpha = 0.0;
 

--- a/osu.Game.Resources/Shaders/sh_TriangleBorder.fs
+++ b/osu.Game.Resources/Shaders/sh_TriangleBorder.fs
@@ -36,7 +36,7 @@ void main(void)
         return;
     }
 
-    highp float dst1 = dstToLine(vec2(0.0, 1.0), vec2(1.0), pixelPos);
+    highp float dst1 = 1.0 - pixelPos.y;
     highp float dst2 = dstToLine(vec2(1.0), vec2(0.5, 0.0), pixelPos);
     highp float dst3 = dstToLine(vec2(0.0, 1.0), vec2(0.5, 0.0), pixelPos);
     highp float dst = min(min(dst1, dst2), dst3);

--- a/osu.Game.Resources/Shaders/sh_TriangleBorder.fs
+++ b/osu.Game.Resources/Shaders/sh_TriangleBorder.fs
@@ -16,9 +16,14 @@ layout(location = 0) out vec4 o_Colour;
 // Distance to the line which starts at (0.0, 1.0) and ends at (0.5, 0.0)
 highp float dstToSideLine(highp vec2 pixelPos)
 {
-    highp vec2 a = vec2(0.4472, -0.8944); // (end - start) / distance(end, start)
-    highp vec2 closest = dot(a, pixelPos - vec2(0.0, 1.0)) * a + vec2(0.0, 1.0); // closest point on a line from given position
-    return distance(closest, pixelPos);
+    // Unit vector in the direction of the line.
+    const highp vec2 v = vec2(0.4472, -0.8944);
+
+    // Vector in direction of the pixel.
+    highp vec2 r = vec2(pixelPos.x, pixelPos.y - 1.0);
+
+    // Cross product of the two vectors.
+    return abs(v.x * r.y - v.y * r.x);
 }
 
 void main(void)

--- a/osu.Game.Resources/Shaders/sh_TriangleBorder.fs
+++ b/osu.Game.Resources/Shaders/sh_TriangleBorder.fs
@@ -13,11 +13,11 @@ layout(std140, set = 0, binding = 0) uniform m_BorderData
 
 layout(location = 0) out vec4 o_Colour;
 
-highp float dstToLine(highp vec2 start, highp vec2 end, highp vec2 pixelPos)
+// Distance to the line with the points (0.0, 1.0) and (0.5, 0.0)
+highp float dstToSideLine(highp vec2 pixelPos)
 {
-    highp float lineLength = distance(end, start);
-    highp vec2 a = (end - start) / lineLength; // Within the scope of this shader line length won't be 0
-    highp vec2 closest = clamp(dot(a, pixelPos - start), 0.0, lineLength) * a + start; // closest point on a line from given position
+    highp vec2 a = vec2(0.4472, -0.8944);
+    highp vec2 closest = dot(a, pixelPos - vec2(0.0, 1.0)) * a + vec2(0.0, 1.0); // closest point on a line from given position
     return distance(closest, pixelPos);
 }
 
@@ -33,9 +33,7 @@ void main(void)
         return;
     }
 
-    highp float dstToBottom = 1.0 - pixelPos.y;
-    highp float dstToSide = dstToLine(vec2(0.0, 1.0), vec2(0.5, 0.0), pixelPos);
-    highp float dst = min(dstToBottom, dstToSide);
+    highp float dst = min(1.0 - pixelPos.y, dstToSideLine(pixelPos));
 
     lowp float alpha = 0.0;
 


### PR DESCRIPTION
Basically replaces 3 distance to line calculations with 1 simpler one.
Performance improvement is minuscule, but exists.

| master | pr |
| --- | --- |
| ![old](https://github.com/ppy/osu-resources/assets/22874522/5770a734-8ccb-4016-8677-0b978d81fba8) | ![Снимок экрана (34)](https://github.com/ppy/osu-resources/assets/22874522/c4348279-f3df-403a-a514-48415cdb227e) |
