### PR TITLE
Add "press enter" to chatbox placeholder string

### DIFF
--- a/osu.Game.Resources/Localisation/Web/ChatStrings.cs
+++ b/osu.Game.Resources/Localisation/Web/ChatStrings.cs
@@ -137,7 +137,7 @@ namespace osu.Game.Resources.Localisation.Web
         /// <summary>
         /// "type message..."
         /// </summary>
-        public static LocalisableString InputPlaceholder => new TranslatableString(getKey(@"input.placeholder"), @"type message...");
+        public static LocalisableString InputPlaceholder => new TranslatableString(getKey(@"input.placeholder"), @"press enter to type message...");
 
         /// <summary>
         /// "Send"


### PR DESCRIPTION
Addresses [osu! Issue #292264](https://github.com/ppy/osu/issues/29264) by adding "press enter" to the chat placeholder text.