### PR TITLE
Add a custom shader for BeatmapBackground to handle background dim colour changes

### DIFF
--- a/osu.Game.Resources/Shaders/sh_BeatmapBackground.fs
+++ b/osu.Game.Resources/Shaders/sh_BeatmapBackground.fs
@@ -18,6 +18,7 @@ layout(location = 0) out vec4 o_Colour;
 void main(void) 
 {
     vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
-    o_Colour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_Texture, m_Sampler, -0.9), wrappedCoord);
-    o_Colour = mix(o_Colour, m_DimColour, m_DimLevel);
+    vec4 texel = wrappedSampler(wrappedCoord, v_TexRect, m_Texture, m_Sampler, -0.9);
+    texel = mix(texel, m_DimColour, m_DimLevel);
+    o_Colour = getRoundedColor(texel, wrappedCoord);
 }

--- a/osu.Game.Resources/Shaders/sh_BeatmapBackground.fs
+++ b/osu.Game.Resources/Shaders/sh_BeatmapBackground.fs
@@ -1,0 +1,16 @@
+#include "sh_Utils.h"
+#include "sh_Masking.h"
+#include "sh_TextureWrapping.h"
+
+layout(location = 2) in mediump vec2 v_TexCoord;
+
+layout(set = 0, binding = 0) uniform lowp texture2D m_Texture;
+layout(set = 0, binding = 1) uniform lowp sampler m_Sampler;
+
+layout(location = 0) out vec4 o_Colour;
+
+void main(void) 
+{
+    vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
+    o_Colour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_Texture, m_Sampler, -0.9), wrappedCoord);
+}

--- a/osu.Game.Resources/Shaders/sh_BeatmapBackground.fs
+++ b/osu.Game.Resources/Shaders/sh_BeatmapBackground.fs
@@ -9,8 +9,8 @@ layout(set = 0, binding = 1) uniform lowp sampler m_Sampler;
 
 layout(std140, set = 1, binding = 0) uniform m_BeatmapBackgroundParameters
 {
+    lowp vec4 m_DimColour;
     lowp float m_DimLevel;
-    lowp float m_DimColour;
 };
 
 layout(location = 0) out vec4 o_Colour;
@@ -19,7 +19,5 @@ void main(void)
 {
     vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
     o_Colour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_Texture, m_Sampler, -0.9), wrappedCoord);
-
-    vec4 dimColour = vec4(m_DimColour, m_DimColour, m_DimColour, 1.0);
-    o_Colour = mix(o_Colour, dimColour, m_DimLevel);
+    o_Colour = mix(o_Colour, m_DimColour, m_DimLevel);
 }

--- a/osu.Game.Resources/Shaders/sh_BeatmapBackground.fs
+++ b/osu.Game.Resources/Shaders/sh_BeatmapBackground.fs
@@ -19,4 +19,7 @@ void main(void)
 {
     vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
     o_Colour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_Texture, m_Sampler, -0.9), wrappedCoord);
+
+    vec4 dimColour = vec4(m_DimColour, m_DimColour, m_DimColour, 1.0);
+    o_Colour = mix(o_Colour, dimColour, m_DimLevel);
 }

--- a/osu.Game.Resources/Shaders/sh_BeatmapBackground.fs
+++ b/osu.Game.Resources/Shaders/sh_BeatmapBackground.fs
@@ -7,6 +7,12 @@ layout(location = 2) in mediump vec2 v_TexCoord;
 layout(set = 0, binding = 0) uniform lowp texture2D m_Texture;
 layout(set = 0, binding = 1) uniform lowp sampler m_Sampler;
 
+layout(std140, set = 1, binding = 0) uniform m_BeatmapBackgroundParameters
+{
+    lowp float m_DimLevel;
+    lowp float m_DimColour;
+};
+
 layout(location = 0) out vec4 o_Colour;
 
 void main(void) 

--- a/osu.Game.Resources/Shaders/sh_BeatmapBackground.fs
+++ b/osu.Game.Resources/Shaders/sh_BeatmapBackground.fs
@@ -7,7 +7,7 @@ layout(location = 2) in mediump vec2 v_TexCoord;
 layout(set = 0, binding = 0) uniform lowp texture2D m_Texture;
 layout(set = 0, binding = 1) uniform lowp sampler m_Sampler;
 
-layout(std140, set = 1, binding = 0) uniform m_DimmableBeatmapBackgroundParameters
+layout(std140, set = 1, binding = 0) uniform m_BeatmapBackgroundParameters
 {
     lowp vec4 m_DimColour;
     lowp float m_DimLevel;

--- a/osu.Game.Resources/Shaders/sh_DimmableBeatmapBackground.fs
+++ b/osu.Game.Resources/Shaders/sh_DimmableBeatmapBackground.fs
@@ -7,7 +7,7 @@ layout(location = 2) in mediump vec2 v_TexCoord;
 layout(set = 0, binding = 0) uniform lowp texture2D m_Texture;
 layout(set = 0, binding = 1) uniform lowp sampler m_Sampler;
 
-layout(std140, set = 1, binding = 0) uniform m_BeatmapBackgroundParameters
+layout(std140, set = 1, binding = 0) uniform m_DimmableBeatmapBackgroundParameters
 {
     lowp vec4 m_DimColour;
     lowp float m_DimLevel;


### PR DESCRIPTION
Handles dimming applied directly to BeatmapBackground separately, allowing to change dim colour. Dimming applied by other sources (like overlays) works the same as in a regular texture shader and is not affected by DimColour.

Companion to https://github.com/ppy/osu/pull/30391